### PR TITLE
docs: Remove usage examples from `LanguageChangedEvent.php` and `UrlLanguageManager.php` documentation.

### DIFF
--- a/src/LanguageChangedEvent.php
+++ b/src/LanguageChangedEvent.php
@@ -21,18 +21,6 @@ use yii\base\Event;
  * - Provides the previous language code via {@see LanguageChangedEvent::oldLanguage}.
  * - Supports null for the old language if not previously set.
  *
- * Usage example:
- * ```php
- * Event::on(
- *     SomeComponent::class,
- *     SomeComponent::EVENT_LANGUAGE_CHANGED,
- *     static function (LanguageChangedEvent $event) {
- *         $new = $event->language;
- *         $old = $event->oldLanguage;
- *     }
- * );
- * ```
- *
  * @see Event for base event.
  *
  * @copyright Copyright (C) 2023 Terabytesoftw.

--- a/src/UrlLanguageManager.php
+++ b/src/UrlLanguageManager.php
@@ -57,21 +57,6 @@ use function usort;
  * - Redirects to canonical URLs based on language and configuration.
  * - Transparent persistence of language selection in session and cookie.
  *
- * Usage example:
- * ```php
- * $manager = new UrlLanguageManager(
- *     [
- *         'languages' => ['en', 'fr', 'de', 'ru' => 'ru'],
- *         'enableLocaleUrls' => true,
- *         'enableLanguageDetection' => true,
- *         'enableLanguagePersistence' => true,
- *     ],
- * );
- *
- * // Generates /fr/site/index for French
- * $url = $manager->createUrl(['site/index', 'language' => 'fr']);
- * ```
- *
  * @see LanguageChangedEvent for event details when language changes.
  * @see UrlManager for base URL management and routing.
  *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Removed usage example code blocks from class-level documentation for language event and URL management components. No changes to functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->