### PR TITLE
refactor: Clean up code in tests for better readability and maintainability.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.1.1 Under development
 
 - Bug #19: Improve language in comments for clarity and consistency in `LanguageChangedEvent.php` and `UrlLanguageManager.php` (@terabytesoftw)
+- Bug #20: Clean up code in tests for better readability and maintainability (@terabytesoftw)
 
 ## 0.1.0 June 20, 2025
 

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
         "ecs": "./vendor/bin/ecs --fix",
         "mutation": "./vendor/bin/infection --threads=4 --ignore-msi-with-no-mutations --only-covered --min-msi=100 --min-covered-msi=100",
         "rector": "./vendor/bin/rector process src",
-        "static": "./vendor/bin/phpstan analyse src --memory-limit=512M",
+        "static": "./vendor/bin/phpstan --memory-limit=512M",
         "tests": "./vendor/bin/phpunit"
     },
     "repositories": [

--- a/ecs.php
+++ b/ecs.php
@@ -31,7 +31,11 @@ return ECSConfig::configure()
             'elements' => [],
         ],
     )
-    ->withFileExtensions(['php'])
+    ->withFileExtensions(
+        [
+            'php',
+        ],
+    )
     ->withPaths(
         [
             __DIR__ . '/src',
@@ -53,4 +57,9 @@ return ECSConfig::configure()
             OrderedTraitsFixer::class,
             SingleQuoteFixer::class,
         ]
+    )
+    ->withSkip(
+        [
+            __DIR__ . '/tests/runtime',
+        ],
     );

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,10 +5,16 @@ parameters:
     bootstrapFiles:
         - tests/bootstrap.php
 
+    excludePaths:
+        analyse:
+            - tests/stub/*
+            - tests/runtime/*
+
     level: max
 
     paths:
         - src
+        - tests
 
     tmpDir: %currentWorkingDirectory%/tests/runtime
 

--- a/src/UrlLanguageManager.php
+++ b/src/UrlLanguageManager.php
@@ -309,6 +309,7 @@ class UrlLanguageManager extends UrlManager
      * @return string the created URL with the appropriate language handling applied.
      *
      * @phpstan-param array<string, string>|string $params
+     *
      * @phpstan-ignore method.childParameterType
      */
     public function createUrl($params): string

--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -11,6 +11,7 @@ use yii\web\NotFoundHttpException;
 use yii2\extensions\localeurls\LanguageChangedEvent;
 
 use function array_column;
+use function session_start;
 
 /**
  * Test suite for {@see LanguageChangedEvent} event functionality and behavior.
@@ -40,12 +41,24 @@ use function array_column;
 #[Group('locale-urls')]
 final class EventTest extends TestCase
 {
+    /**
+     * Indicates whether the language change event is expected to be fired.
+     */
     protected bool $eventExpected = true;
 
+    /**
+     * Indicates whether the language change event has been fired.
+     */
     protected bool $eventFired = false;
 
+    /**
+     * Expected new language after the event is fired.
+     */
     protected string|null $expectedLanguage = null;
 
+    /**
+     * Expected old language before the event is fired.
+     */
     protected string|null $expectedOldLanguage = null;
 
     protected function tearDown(): void
@@ -75,14 +88,14 @@ final class EventTest extends TestCase
 
         $this->expectedLanguage = 'fr';
 
-        $this->assertFalse(
+        self::assertFalse(
             $this->eventFired,
             'Language changed event should not be fired before making the request when no language is persisted.',
         );
 
         $this->mockRequest('/fr/site/page');
 
-        $this->assertTrue(
+        self::assertTrue(
             $this->eventFired,
             'Language changed event should be fired when no language is persisted and a language is detected from URL.',
         );
@@ -90,17 +103,17 @@ final class EventTest extends TestCase
         $loggerMessages = Yii::getLogger()->messages;
         $expectedMessages = array_column($loggerMessages, 0);
 
-        $this->assertContains(
+        self::assertContains(
             'Triggering languageChanged event:  -> fr',
             $expectedMessages,
             'Language changed event should be logged with the new language.',
         );
-        $this->assertContains(
+        self::assertContains(
             'Persisting language \'fr\' in session.',
             $expectedMessages,
             'Persisting language in session should be logged.',
         );
-        $this->assertContains(
+        self::assertContains(
             'Persisting language \'fr\' in cookie.',
             $expectedMessages,
             'Persisting language in cookie should be logged.',
@@ -123,7 +136,7 @@ final class EventTest extends TestCase
             ],
         );
 
-        $this->assertFalse(
+        self::assertFalse(
             $this->eventFired,
             'Language changed event should not be fired before making the request when cookie language matches URL ' .
             'language.',
@@ -131,7 +144,7 @@ final class EventTest extends TestCase
 
         $this->mockRequest('/fr/site/page');
 
-        $this->assertFalse(
+        self::assertFalse(
             $this->eventFired,
             'Language changed event should not be fired when cookie language matches URL language.',
         );
@@ -145,6 +158,7 @@ final class EventTest extends TestCase
     public function testFiresNotIfNoSessionLanguageChange(): void
     {
         @session_start();
+
         $_SESSION['_language'] = 'fr';
 
         $this->mockUrlLanguageManager(
@@ -154,7 +168,7 @@ final class EventTest extends TestCase
             ],
         );
 
-        $this->assertFalse(
+        self::assertFalse(
             $this->eventFired,
             'Language changed event should not be fired before making the request when session language matches URL ' .
             'language.',
@@ -162,7 +176,7 @@ final class EventTest extends TestCase
 
         $this->mockRequest('/fr/site/page');
 
-        $this->assertFalse(
+        self::assertFalse(
             $this->eventFired,
             'Language changed event should not be fired when session language matches URL language.',
         );
@@ -185,14 +199,14 @@ final class EventTest extends TestCase
 
         $this->expectedLanguage = 'fr';
 
-        $this->assertFalse(
+        self::assertFalse(
             $this->eventFired,
             'Language changed event should not be fired before making the request when persistence is disabled.',
         );
 
         $this->mockRequest('/fr/site/page');
 
-        $this->assertFalse(
+        self::assertFalse(
             $this->eventFired,
             'Language changed event should not be fired when language persistence is disabled.',
         );
@@ -217,14 +231,14 @@ final class EventTest extends TestCase
         $this->expectedLanguage = 'fr';
         $this->expectedOldLanguage = 'de';
 
-        $this->assertFalse(
+        self::assertFalse(
             $this->eventFired,
             'Language changed event should not be fired before making the request with different language.',
         );
 
         $this->mockRequest('/fr/site/page');
 
-        $this->assertTrue(
+        self::assertTrue(
             $this->eventFired,
             'Language changed event should be fired when URL language differs from cookie language.',
         );
@@ -251,14 +265,14 @@ final class EventTest extends TestCase
         $this->expectedLanguage = 'fr';
         $this->expectedOldLanguage = 'de';
 
-        $this->assertFalse(
+        self::assertFalse(
             $this->eventFired,
             'Language changed event should not be fired before making the request with different language.',
         );
 
         $this->mockRequest('/fr/site/page');
 
-        $this->assertTrue(
+        self::assertTrue(
             $this->eventFired,
             'Language changed event should be fired when URL language differs from session language.',
         );
@@ -266,9 +280,9 @@ final class EventTest extends TestCase
 
     public function languageChangedHandler(LanguageChangedEvent $event): void
     {
-        $this->assertTrue($this->eventExpected);
-        $this->assertEquals($this->expectedLanguage, $event->language);
-        $this->assertEquals($this->expectedOldLanguage, $event->oldLanguage);
+        self::assertTrue($this->eventExpected);
+        self::assertEquals($this->expectedLanguage, $event->language);
+        self::assertEquals($this->expectedOldLanguage, $event->oldLanguage);
 
         $this->eventFired = true;
     }

--- a/tests/RedirectWithBaseUrlAndScriptNameTest.php
+++ b/tests/RedirectWithBaseUrlAndScriptNameTest.php
@@ -29,12 +29,12 @@ use yii2\extensions\localeurls\tests\base\AbstractRedirect;
 final class RedirectWithBaseUrlAndScriptNameTest extends AbstractRedirect
 {
     /**
-     * @var string Base URL prefix for test scenarios.
+     * Base URL prefix for test scenarios.
      */
     protected string $baseUrl = '/base';
 
     /**
-     * @var bool Whether to show the script name in generated URLs.
+     * Whether to show the script name in generated URL.
      */
     protected bool $showScriptName = true;
 }

--- a/tests/RedirectWithBaseUrlTest.php
+++ b/tests/RedirectWithBaseUrlTest.php
@@ -28,7 +28,7 @@ use yii2\extensions\localeurls\tests\base\AbstractRedirect;
 final class RedirectWithBaseUrlTest extends AbstractRedirect
 {
     /**
-     * @var string Base URL prefix for test scenarios.
+     * Base URL prefix for test scenarios.
      */
     protected string $baseUrl = '/base';
 }

--- a/tests/RedirectWithScriptNameTest.php
+++ b/tests/RedirectWithScriptNameTest.php
@@ -10,8 +10,8 @@ use yii2\extensions\localeurls\tests\base\AbstractRedirect;
 /**
  * Test suite for URL redirection functionality with script name configuration enabled.
  *
- * Extends the base redirection test suite to verify that URL redirection logic correctly handles language detection
- * and redirect rules when the application is configured to show script names in URLs (for example, index.php).
+ * Extends the base redirection test suite to verify that URL redirection logic correctly handles language detection and
+ * redirect rules when the application is configured to show script names in URLs (for example, index.php).
  *
  * Test coverage.
  * - Cookie-based language detection and redirection behavior with script names.
@@ -33,5 +33,8 @@ use yii2\extensions\localeurls\tests\base\AbstractRedirect;
 #[Group('locale-urls')]
 final class RedirectWithScriptNameTest extends AbstractRedirect
 {
+    /**
+     * Whether to show the script name in generated URL.
+     */
     protected bool $showScriptName = true;
 }

--- a/tests/SlugRedirectWithBaseUrlTest.php
+++ b/tests/SlugRedirectWithBaseUrlTest.php
@@ -31,7 +31,7 @@ use yii2\extensions\localeurls\tests\base\AbstractSlugRedirect;
 final class SlugRedirectWithBaseUrlTest extends AbstractSlugRedirect
 {
     /**
-     * @var string Base URL prefix for test scenarios.
+     * Base URL prefix for test scenarios.
      */
     protected string $baseUrl = '/base';
 }

--- a/tests/SlugRedirectWithScriptNameAndBaseUrlTest.php
+++ b/tests/SlugRedirectWithScriptNameAndBaseUrlTest.php
@@ -34,12 +34,12 @@ use yii2\extensions\localeurls\tests\base\AbstractSlugRedirect;
 final class SlugRedirectWithScriptNameAndBaseUrlTest extends AbstractSlugRedirect
 {
     /**
-     * @var string Base URL prefix for test scenarios.
+     * Base URL prefix for test scenarios.
      */
     protected string $baseUrl = '/base';
 
     /**
-     * @var bool Whether to show the script name in generated URLs.
+     * Whether to show the script name in generated URL.
      */
     protected bool $showScriptName = true;
 }

--- a/tests/SlugRedirectWithScriptNameTest.php
+++ b/tests/SlugRedirectWithScriptNameTest.php
@@ -10,9 +10,9 @@ use yii2\extensions\localeurls\tests\base\AbstractSlugRedirect;
 /**
  * Test suite for slug-based URL redirection functionality with script name visibility configuration.
  *
- * Extends the slug redirect test suite to verify redirection behavior when script name visibility is enabled in the
- * URL manager, testing scenarios where applications with slug-based routing show the script name (for example,
- * `index.php`) in generated URLs.
+ * Extends the slug redirect test suite to verify redirection behavior when script name visibility is enabled in the URL
+ * manager, testing scenarios where applications with slug-based routing show the script name (for example, `index.php`)
+ * in generated URLs.
  *
  * Test coverage.
  * - Language code placement in slug URLs with script name visibility.
@@ -31,7 +31,7 @@ use yii2\extensions\localeurls\tests\base\AbstractSlugRedirect;
 final class SlugRedirectWithScriptNameTest extends AbstractSlugRedirect
 {
     /**
-     * @var bool Whether to show the script name in generated URLs.
+     * Whether to show the script name in generated URL.
      */
     protected bool $showScriptName = true;
 }

--- a/tests/UrlCreationWithBaseUrlAndScriptNameTest.php
+++ b/tests/UrlCreationWithBaseUrlAndScriptNameTest.php
@@ -19,7 +19,7 @@ use yii2\extensions\localeurls\tests\base\AbstractUrlCreation;
  * - Combined base URL and script name in generated URLs.
  * - Language code placement with base URL and script name.
  * - Parameter and query string preservation in complex URL structures.
- * - Script name visibility in generated URLs.
+ * - Script name visibility in generated URL.
  * - URL generation accuracy with subdirectory deployment and script name visibility.
  * - URL normalization with base URL and script name configuration.
  *
@@ -30,12 +30,12 @@ use yii2\extensions\localeurls\tests\base\AbstractUrlCreation;
 final class UrlCreationWithBaseUrlAndScriptNameTest extends AbstractUrlCreation
 {
     /**
-     * @var string Base URL prefix for test scenarios.
+     * Base URL prefix for test scenarios.
      */
     protected string $baseUrl = '/base';
 
     /**
-     * @var bool Whether to show the script name in generated URLs.
+     * Whether to show the script name in generated URL.
      */
     protected bool $showScriptName = true;
 }

--- a/tests/UrlCreationWithBaseUrlTest.php
+++ b/tests/UrlCreationWithBaseUrlTest.php
@@ -29,7 +29,7 @@ use yii2\extensions\localeurls\tests\base\AbstractUrlCreation;
 final class UrlCreationWithBaseUrlTest extends AbstractUrlCreation
 {
     /**
-     * @var string Base URL prefix for test scenarios.
+     * Base URL prefix for test scenarios.
      */
     protected string $baseUrl = '/base';
 }

--- a/tests/UrlCreationWithScriptNameTest.php
+++ b/tests/UrlCreationWithScriptNameTest.php
@@ -21,7 +21,7 @@ use yii2\extensions\localeurls\tests\base\AbstractUrlCreation;
  * - Consistency of URL generation across different configurations.
  * - Language code placement with script name configuration.
  * - Parameter and query string handling with visible script name.
- * - Script name visibility in generated URLs.
+ * - Script name visibility in generated URL.
  * - SEO-friendly URL structure with script name.
  * - URL normalization and structure with script name present.
  *
@@ -32,7 +32,7 @@ use yii2\extensions\localeurls\tests\base\AbstractUrlCreation;
 final class UrlCreationWithScriptNameTest extends AbstractUrlCreation
 {
     /**
-     * @var bool Whether to show the script name in generated URLs.
+     * Whether to show the script name in generated URL.
      */
     protected bool $showScriptName = true;
 }

--- a/tests/UrlLanguageManagerWithBaseUrlTest.php
+++ b/tests/UrlLanguageManagerWithBaseUrlTest.php
@@ -28,7 +28,7 @@ use yii2\extensions\localeurls\tests\base\AbstractUrlLanguageManager;
 final class UrlLanguageManagerWithBaseUrlTest extends AbstractUrlLanguageManager
 {
     /**
-     * @var string Base URL prefix for test scenarios.
+     * Base URL prefix for test scenarios.
      */
     protected string $baseUrl = '/base';
 }

--- a/tests/UrlLanguageManagerWithScriptNameAndBaseUrlTest.php
+++ b/tests/UrlLanguageManagerWithScriptNameAndBaseUrlTest.php
@@ -20,7 +20,7 @@ use yii2\extensions\localeurls\tests\base\AbstractUrlLanguageManager;
  * - Combined base URL and script name in language detection and URL generation.
  * - Language code placement with base URL and script name configuration.
  * - Parameter and query string preservation in complex URL structures.
- * - Script name visibility in generated and parsed URLs.
+ * - Script name visibility in generated and parsed URL.
  * - Subdirectory deployment scenarios with language-aware routing.
  * - URL normalization and language switching with both base URL and script name.
  *
@@ -31,12 +31,12 @@ use yii2\extensions\localeurls\tests\base\AbstractUrlLanguageManager;
 final class UrlLanguageManagerWithScriptNameAndBaseUrlTest extends AbstractUrlLanguageManager
 {
     /**
-     * @var string Base URL prefix for test scenarios.
+     * Base URL prefix for test scenarios.
      */
     protected string $baseUrl = '/base';
 
     /**
-     * @var bool Whether to show the script name in generated URLs.
+     * Whether to show the script name in generated URL.
      */
     protected bool $showScriptName = true;
 }

--- a/tests/UrlLanguageManagerWithScriptNameTest.php
+++ b/tests/UrlLanguageManagerWithScriptNameTest.php
@@ -29,7 +29,7 @@ use yii2\extensions\localeurls\tests\base\AbstractUrlLanguageManager;
 final class UrlLanguageManagerWithScriptNameTest extends AbstractUrlLanguageManager
 {
     /**
-     * @var bool Whether to show the script name in generated URLs.
+     * Whether to show the script name in generated URL.
      */
     protected bool $showScriptName = true;
 }

--- a/tests/base/AbstractUrlLanguageManager.php
+++ b/tests/base/AbstractUrlLanguageManager.php
@@ -14,7 +14,7 @@ use yii2\extensions\localeurls\UrlLanguageManager;
 use function array_column;
 
 /**
- * Base class for language-aware URL manager and language detection tests in the Yii2 LocaleUrls extension.
+ * Base class for language-aware URL manager and language detection tests in the Yii LocaleUrls extension.
  *
  * Provides comprehensive tests for language code extraction, persistence, and normalization, ensuring correct handling
  * of language selection, alias mapping, disabling of detection or persistence, and robust fallback logic across
@@ -55,29 +55,28 @@ abstract class AbstractUrlLanguageManager extends TestCase
                 'languageCookieDuration' => false,
             ],
         );
-
         $this->mockRequest('/en-us/site/page');
 
-        $this->assertSame(
+        self::assertSame(
             'en-US',
             Yii::$app->language,
             'Application language should be set to \'en-US\' when language is present in the URL and cookie is ' .
             'disabled.',
         );
-        $this->assertSame(
+        self::assertSame(
             'en-US',
             Yii::$app->session->get('_language'),
             'Session \'_language\' should be set to \'en-US\' when language is present in the URL and cookie is ' .
             'disabled.',
         );
-        $this->assertNull(
+        self::assertNull(
             Yii::$app->response->cookies->get('_language'),
             'Language cookie should not be set when \'languageCookieDuration\' is false.',
         );
 
         $request = Yii::$app->request;
 
-        $this->assertSame(
+        self::assertSame(
             'site/page',
             $request->pathInfo,
             'Request pathInfo should be \'site/page\' after language code is removed from the URL.',
@@ -97,7 +96,6 @@ abstract class AbstractUrlLanguageManager extends TestCase
                 'enableLanguageDetection' => false,
             ],
         );
-
         $this->mockRequest(
             '/site/page',
             [
@@ -105,7 +103,7 @@ abstract class AbstractUrlLanguageManager extends TestCase
             ],
         );
 
-        $this->assertSame(
+        self::assertSame(
             'en',
             Yii::$app->language,
             'Application language should default to \'en\' when language detection is disabled, regardless of ' .
@@ -114,7 +112,7 @@ abstract class AbstractUrlLanguageManager extends TestCase
 
         $request = Yii::$app->request;
 
-        $this->assertSame(
+        self::assertSame(
             'site/page',
             $request->pathInfo,
             'Request pathInfo should be \'site/page\' when no language code is present in the URL.',
@@ -134,26 +132,25 @@ abstract class AbstractUrlLanguageManager extends TestCase
                 'enableLanguagePersistence' => false,
             ],
         );
-
         $this->mockRequest('/en-us/site/page');
 
-        $this->assertSame(
+        self::assertSame(
             'en-US',
             Yii::$app->language,
             'Application language should be set to \'en-US\' from the URL even when language persistence is disabled.',
         );
-        $this->assertNull(
+        self::assertNull(
             Yii::$app->session->get('_language'),
             'Session \'_language\' should not be set when \'enableLanguagePersistence\' is false.',
         );
-        $this->assertNull(
+        self::assertNull(
             Yii::$app->response->cookies->get('_language'),
             'Language cookie should not be set when \'enableLanguagePersistence\' is false.',
         );
 
         $request = Yii::$app->request;
 
-        $this->assertSame(
+        self::assertSame(
             'site/page',
             $request->pathInfo,
             'Request pathInfo should be \'site/page\' after language code is removed from the URL.',
@@ -173,10 +170,9 @@ abstract class AbstractUrlLanguageManager extends TestCase
                 'languageSessionKey' => false,
             ],
         );
-
         $this->mockRequest('/en-us/site/page');
 
-        $this->assertSame(
+        self::assertSame(
             'en-US',
             Yii::$app->language,
             'Application language should be set to \'en-US\' from the URL when session persistence is disabled.',
@@ -184,11 +180,11 @@ abstract class AbstractUrlLanguageManager extends TestCase
 
         $cookie = Yii::$app->response->cookies->get('_language');
 
-        $this->assertNotNull(
+        self::assertNotNull(
             $cookie,
             "Language cookie should be set when 'languageSessionKey' is false and language is present in the URL.",
         );
-        $this->assertSame(
+        self::assertSame(
             'en-US',
             $cookie->value,
             'Language cookie value should be \'en-US\' when session persistence is disabled and language is present ' .
@@ -197,7 +193,7 @@ abstract class AbstractUrlLanguageManager extends TestCase
 
         $request = Yii::$app->request;
 
-        $this->assertSame(
+        self::assertSame(
             'site/page',
             $request->pathInfo,
             'Request pathInfo should be \'site/page\' after language code is removed from the URL.',
@@ -216,15 +212,14 @@ abstract class AbstractUrlLanguageManager extends TestCase
                 'languages' => ['en-US', 'en', 'deutsch' => 'de'],
             ],
         );
-
         $this->mockRequest('/deutsch/site/page');
 
-        $this->assertSame(
+        self::assertSame(
             'de',
             Yii::$app->language,
             'Application language should be set to \'de\' when using a language alias in the URL.',
         );
-        $this->assertSame(
+        self::assertSame(
             'de',
             Yii::$app->session->get('_language'),
             'Session \'_language\' should be set to \'de\' when using a language alias in the URL.',
@@ -232,11 +227,11 @@ abstract class AbstractUrlLanguageManager extends TestCase
 
         $cookie = Yii::$app->response->cookies->get('_language');
 
-        $this->assertNotNull(
+        self::assertNotNull(
             $cookie,
             'Language cookie should be set when using a language alias in the URL.',
         );
-        $this->assertSame(
+        self::assertSame(
             'de',
             $cookie->value,
             'Language cookie value should be \'de\' when using a language alias in the URL.',
@@ -244,7 +239,7 @@ abstract class AbstractUrlLanguageManager extends TestCase
 
         $request = Yii::$app->request;
 
-        $this->assertSame(
+        self::assertSame(
             'site/page',
             $request->pathInfo,
             'Request pathInfo should be \'site/page\' after language alias is removed from the URL.',
@@ -263,15 +258,14 @@ abstract class AbstractUrlLanguageManager extends TestCase
                 'languages' => ['en-US', 'deutsch' => 'de', 'sr-Latn'],
             ],
         );
-
         $this->mockRequest('/sr-latn/site/page');
 
-        $this->assertSame(
+        self::assertSame(
             'sr-Latn',
             Yii::$app->language,
             'Application language should be set to \'sr-Latn\' when using a language with script code in the URL.',
         );
-        $this->assertSame(
+        self::assertSame(
             'sr-Latn',
             Yii::$app->session->get('_language'),
             'Session \'_language\' should be set to \'sr-Latn\' when using a language with script code in the URL.',
@@ -279,11 +273,11 @@ abstract class AbstractUrlLanguageManager extends TestCase
 
         $cookie = Yii::$app->response->cookies->get('_language');
 
-        $this->assertNotNull(
+        self::assertNotNull(
             $cookie,
             'Language cookie should be set when using a language with script code in the URL.',
         );
-        $this->assertSame(
+        self::assertSame(
             'sr-Latn',
             $cookie->value,
             'Language cookie value should be \'sr-Latn\' when using a language with script code in the URL.',
@@ -291,7 +285,7 @@ abstract class AbstractUrlLanguageManager extends TestCase
 
         $request = Yii::$app->request;
 
-        $this->assertSame(
+        self::assertSame(
             'site/page',
             $request->pathInfo,
             'Request pathInfo should be \'site/page\' after language with script code is removed from the URL.',
@@ -310,15 +304,14 @@ abstract class AbstractUrlLanguageManager extends TestCase
                 'languages' => ['en-US', 'deutsch' => 'de', 'es-*'],
             ],
         );
-
         $this->mockRequest('/es-bo/site/page');
 
-        $this->assertSame(
+        self::assertSame(
             'es-BO',
             Yii::$app->language,
             'Application language should be set to \'es-BO\' when using a wildcard country language in the URL.',
         );
-        $this->assertSame(
+        self::assertSame(
             'es-BO',
             Yii::$app->session->get('_language'),
             'Session \'_language\' should be set to \'es-BO\' when using a wildcard country language in the URL.',
@@ -326,11 +319,11 @@ abstract class AbstractUrlLanguageManager extends TestCase
 
         $cookie = Yii::$app->response->cookies->get('_language');
 
-        $this->assertNotNull(
+        self::assertNotNull(
             $cookie,
             'Language cookie should be set when using a wildcard country language in the URL.',
         );
-        $this->assertSame(
+        self::assertSame(
             'es-BO',
             $cookie->value,
             'Language cookie value should be \'es-BO\' when using a wildcard country language in the URL.',
@@ -338,7 +331,7 @@ abstract class AbstractUrlLanguageManager extends TestCase
 
         $request = Yii::$app->request;
 
-        $this->assertSame(
+        self::assertSame(
             'site/page',
             $request->pathInfo,
             'Request pathInfo should be \'site/page\' after wildcard country language is removed from the URL.',
@@ -367,7 +360,7 @@ abstract class AbstractUrlLanguageManager extends TestCase
         $loggerMessages = Yii::getLogger()->messages;
         $expectedMessages = array_column($loggerMessages, 0);
 
-        $this->assertContains(
+        self::assertContains(
             'Found persisted language \'fr\' in cookie.',
             $expectedMessages,
             'Logger should record a message when an invalid language \'fr\' is found in the cookie and not in the ' .
@@ -399,7 +392,7 @@ abstract class AbstractUrlLanguageManager extends TestCase
         $loggerMessages = Yii::getLogger()->messages;
         $expectedMessages = array_column($loggerMessages, 0);
 
-        $this->assertContains(
+        self::assertContains(
             'Found persisted language \'fr\' in session.',
             $expectedMessages,
             'Logger should record a message when an invalid language \'fr\' is found in the session and not in the ' .
@@ -423,7 +416,6 @@ abstract class AbstractUrlLanguageManager extends TestCase
                 ],
             ],
         );
-
         $this->mockRequest(
             '/site/page',
             [
@@ -431,7 +423,7 @@ abstract class AbstractUrlLanguageManager extends TestCase
             ],
         );
 
-        $this->assertSame(
+        self::assertSame(
             'en',
             Yii::$app->language,
             'Application language should default to \'en\' when locale URLs are disabled, regardless of acceptable ' .
@@ -440,7 +432,7 @@ abstract class AbstractUrlLanguageManager extends TestCase
 
         $request = Yii::$app->request;
 
-        $this->assertSame(
+        self::assertSame(
             'site/page',
             $request->pathInfo,
             'Request pathInfo should be \'site/page\' when locale URLs are disabled and no language code is present ' .
@@ -448,24 +440,24 @@ abstract class AbstractUrlLanguageManager extends TestCase
         );
 
         // If a URL rule is configured for the home URL, it will always have a trailing slash
-        $this->assertSame(
+        self::assertSame(
             $this->prepareUrl('/'),
             Url::to(['/site/index']),
             'Home URL should always have a trailing slash when a URL rule is configured for it.',
         );
-        $this->assertSame(
+        self::assertSame(
             $this->prepareUrl('/?x=y'),
             Url::to(['/site/index', 'x' => 'y']),
             'Home URL with query parameters should have a trailing slash when a URL rule is configured for it.',
         );
 
         // Other URLs have no trailing slash
-        $this->assertSame(
+        self::assertSame(
             $this->prepareUrl('/site/test'),
             Url::to(['/site/test']),
             'Other URLs should not have a trailing slash when locale URLs are disabled.',
         );
-        $this->assertSame(
+        self::assertSame(
             $this->prepareUrl('/site/test?x=y'),
             Url::to(['/site/test', 'x' => 'y']),
             'Other URLs with query parameters should not have a trailing slash when locale URLs are disabled.',
@@ -484,7 +476,6 @@ abstract class AbstractUrlLanguageManager extends TestCase
                 'languages' => [],
             ],
         );
-
         $this->mockRequest(
             '/site/page',
             [
@@ -492,7 +483,7 @@ abstract class AbstractUrlLanguageManager extends TestCase
             ],
         );
 
-        $this->assertSame(
+        self::assertSame(
             'en',
             Yii::$app->language,
             'Application language should default to \'en\' when no languages are configured, regardless of ' .
@@ -501,7 +492,7 @@ abstract class AbstractUrlLanguageManager extends TestCase
 
         $request = Yii::$app->request;
 
-        $this->assertSame(
+        self::assertSame(
             'site/page',
             $request->pathInfo,
             'Request pathInfo should be \'site/page\' when no languages are configured and no language code is ' .
@@ -526,7 +517,6 @@ abstract class AbstractUrlLanguageManager extends TestCase
                 ],
             ],
         );
-
         $this->mockRequest(
             '/site/page',
             [
@@ -534,7 +524,7 @@ abstract class AbstractUrlLanguageManager extends TestCase
             ],
         );
 
-        $this->assertSame(
+        self::assertSame(
             'en',
             Yii::$app->language,
             'Application language should remain \'en\' when the URL matches an ignored pattern, regardless of ' .
@@ -543,7 +533,7 @@ abstract class AbstractUrlLanguageManager extends TestCase
 
         $request = Yii::$app->request;
 
-        $this->assertSame(
+        self::assertSame(
             'site/page',
             $request->pathInfo,
             'Request pathInfo should remain \'site/page\' when the URL matches an ignored pattern and no language ' .
@@ -553,7 +543,7 @@ abstract class AbstractUrlLanguageManager extends TestCase
         $loggerMessages = Yii::getLogger()->messages;
         $expectedMessages = array_column($loggerMessages, 0);
 
-        $this->assertContains(
+        self::assertContains(
             'Ignore pattern \'#^site/page#\' matches \'site/page.\' Skipping language processing.',
             $expectedMessages,
             'First log message should indicate that the URL is ignored due to matching an ignored pattern.',
@@ -575,9 +565,9 @@ abstract class AbstractUrlLanguageManager extends TestCase
         try {
             $this->mockRequest('/site/page');
 
-            $this->fail('Expected redirection exception was not thrown.');
+            self::fail('Expected redirection exception was not thrown.');
         } catch (Exception $e) {
-            $this->assertStringContainsString(
+            self::assertStringContainsString(
                 '/en-us-variant/site/page',
                 $e->getMessage(),
                 'Redirect URL should preserve all parts after first dash when explode limit is \'2\'.',
@@ -597,9 +587,9 @@ abstract class AbstractUrlLanguageManager extends TestCase
         try {
             $this->mockRequest('/site/page');
 
-            $this->fail('Expected redirection exception was not thrown for second test case.');
+            self::fail('Expected redirection exception was not thrown for second test case.');
         } catch (Exception $e) {
-            $this->assertStringContainsString(
+            self::assertStringContainsString(
                 '/es-mx-variant-extended/site/page',
                 $e->getMessage(),
                 'Redirect URL should handle multiple dashes correctly with explode limit of \'2\'.',
@@ -619,10 +609,9 @@ abstract class AbstractUrlLanguageManager extends TestCase
                 'languages' => ['en-US', 'en', 'de'],
             ],
         );
-
         $this->mockRequest('/');
 
-        $this->assertSame(
+        self::assertSame(
             'en',
             Yii::$app->language,
             'Application language should default to \'en\' when no language code is specified in the URL.',
@@ -630,7 +619,7 @@ abstract class AbstractUrlLanguageManager extends TestCase
 
         $request = Yii::$app->request;
 
-        $this->assertSame(
+        self::assertSame(
             '',
             $request->pathInfo,
             'Request pathInfo should be empty when no language code is specified and the URL is root (\'/\').',
@@ -649,15 +638,14 @@ abstract class AbstractUrlLanguageManager extends TestCase
                 'languages' => ['en-US', 'en', 'de'],
             ],
         );
-
         $this->mockRequest('/en-us/site/page');
 
-        $this->assertSame(
+        self::assertSame(
             'en-US',
             Yii::$app->language,
             'Application language should be set to \'en-US\' when the language code is present in the URL.',
         );
-        $this->assertSame(
+        self::assertSame(
             'en-US',
             Yii::$app->session->get('_language'),
             'Session \'_language\' should be set to \'en-US\' when the language code is present in the URL.',
@@ -665,11 +653,11 @@ abstract class AbstractUrlLanguageManager extends TestCase
 
         $cookie = Yii::$app->response->cookies->get('_language');
 
-        $this->assertNotNull(
+        self::assertNotNull(
             $cookie,
             'Language cookie should be set when the language code is present in the URL.',
         );
-        $this->assertSame(
+        self::assertSame(
             'en-US',
             $cookie->value,
             'Language cookie value should be \'en-US\' when the language code is present in the URL.',
@@ -677,7 +665,7 @@ abstract class AbstractUrlLanguageManager extends TestCase
 
         $request = Yii::$app->request;
 
-        $this->assertSame(
+        self::assertSame(
             'site/page',
             $request->pathInfo,
             'Request pathInfo should be \'site/page\' after the language code is removed from the URL.',
@@ -696,16 +684,15 @@ abstract class AbstractUrlLanguageManager extends TestCase
                 'languages' => ['en-US', 'de-*'],
             ],
         );
-
         $this->mockRequest('/de/site/page');
 
-        $this->assertSame(
+        self::assertSame(
             'de',
             Yii::$app->language,
             'Application language should be set to \'de\' when the language code matches a wildcard in the ' .
             'configuration.',
         );
-        $this->assertSame(
+        self::assertSame(
             'de',
             Yii::$app->session->get('_language'),
             'Session \'_language\' should be set to \'de\' when the language code matches a wildcard in the ' .
@@ -714,11 +701,11 @@ abstract class AbstractUrlLanguageManager extends TestCase
 
         $cookie = Yii::$app->response->cookies->get('_language');
 
-        $this->assertNotNull(
+        self::assertNotNull(
             $cookie,
             'Language cookie should be set when the language code matches a wildcard in the configuration.',
         );
-        $this->assertSame(
+        self::assertSame(
             'de',
             $cookie->value,
             'Language cookie value should be \'de\' when the language code matches a wildcard in the configuration.',
@@ -726,7 +713,7 @@ abstract class AbstractUrlLanguageManager extends TestCase
 
         $request = Yii::$app->request;
 
-        $this->assertSame(
+        self::assertSame(
             'site/page',
             $request->pathInfo,
             'Request pathInfo should be \'site/page\' after the language code is removed from the URL when matching ' .
@@ -747,16 +734,15 @@ abstract class AbstractUrlLanguageManager extends TestCase
                 'keepUppercaseLanguageCode' => true,
             ],
         );
-
         $this->mockRequest('/en-US/site/page');
 
-        $this->assertSame(
+        self::assertSame(
             'en-US',
             Yii::$app->language,
             'Application language should be set to \'en-US\' when the language code is present in the URL and ' .
             'uppercase is enabled.',
         );
-        $this->assertSame(
+        self::assertSame(
             'en-US',
             Yii::$app->session->get('_language'),
             'Session \'_language\' should be set to \'en-US\' when the language code is present in the URL and ' .
@@ -765,11 +751,11 @@ abstract class AbstractUrlLanguageManager extends TestCase
 
         $cookie = Yii::$app->response->cookies->get('_language');
 
-        $this->assertNotNull(
+        self::assertNotNull(
             $cookie,
             'Language cookie should be set when the language code is present in the URL and uppercase is enabled.',
         );
-        $this->assertSame(
+        self::assertSame(
             'en-US',
             $cookie->value,
             'Language cookie value should be \'en-US\' when the language code is present in the URL and uppercase is ' .
@@ -778,7 +764,7 @@ abstract class AbstractUrlLanguageManager extends TestCase
 
         $request = Yii::$app->request;
 
-        $this->assertSame(
+        self::assertSame(
             'site/page',
             $request->pathInfo,
             'Request pathInfo should be \'site/page\' after the language code is removed from the URL and uppercase ' .
@@ -798,16 +784,15 @@ abstract class AbstractUrlLanguageManager extends TestCase
                 'languages' => ['en', 'en-US', 'de'],
             ],
         );
-
         $this->mockRequest('/en-us/site/page');
 
-        $this->assertSame(
+        self::assertSame(
             'en-US',
             Yii::$app->language,
             'Application language should be set to \'en-US\' when the language code is present in the URL and ' .
             'matches the order in the configuration.',
         );
-        $this->assertSame(
+        self::assertSame(
             'en-US',
             Yii::$app->session->get('_language'),
             'Session \'_language\' should be set to \'en-US\' when the language code is present in the URL and ' .
@@ -816,12 +801,12 @@ abstract class AbstractUrlLanguageManager extends TestCase
 
         $cookie = Yii::$app->response->cookies->get('_language');
 
-        $this->assertNotNull(
+        self::assertNotNull(
             $cookie,
             'Language cookie should be set when the language code is present in the URL and matches the order in the ' .
             'configuration.',
         );
-        $this->assertSame(
+        self::assertSame(
             'en-US',
             $cookie->value,
             'Language cookie value should be \'en-US\' when the language code is present in the URL and matches the ' .
@@ -830,7 +815,7 @@ abstract class AbstractUrlLanguageManager extends TestCase
 
         $request = Yii::$app->request;
 
-        $this->assertSame(
+        self::assertSame(
             'site/page',
             $request->pathInfo,
             'Request pathInfo should be \'site/page\' after the language code is removed from the URL and matches ' .
@@ -838,6 +823,9 @@ abstract class AbstractUrlLanguageManager extends TestCase
         );
     }
 
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     */
     public function testThrowInvalidConfigExceptionWhenEnablePrettyUrlIsFalse(): void
     {
         $this->mockWebApplication();
@@ -853,6 +841,9 @@ abstract class AbstractUrlLanguageManager extends TestCase
         );
     }
 
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     */
     public function testThrowNotFoundHttpExceptionWhenUrlIsInvalid(): void
     {
         $this->mockUrlLanguageManager(
@@ -862,13 +853,13 @@ abstract class AbstractUrlLanguageManager extends TestCase
                 'enableStrictParsing' => true,
             ],
         );
-
         $this->mockWebApplication();
 
         $_COOKIE['_language'] = 'de';
 
         $urlManager = Yii::$app->urlManager;
         $request = Yii::$app->request;
+
         $request->setUrl('/de/invalid-url');
 
         $this->expectException(NotFoundHttpException::class);

--- a/tests/stub/UrlRule.php
+++ b/tests/stub/UrlRule.php
@@ -9,6 +9,17 @@ use yii\base\Exception;
 use yii\helpers\Url;
 use yii\web\UrlRuleInterface;
 
+/**
+ * Custom URL rule implementation for testing language-based routing and redirects.
+ *
+ * Provides a minimal UrlRuleInterface implementation for simulating language slug handling in URLs and request parsing.
+ *
+ * This class is used in test scenarios to verify correct URL creation and request parsing based on language slugs,
+ * including redirect logic and exception handling for test environments.
+ *
+ * @copyright Copyright (C) 2023 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
 final class UrlRule implements UrlRuleInterface
 {
     public function createUrl($manager, $route, $params)
@@ -47,12 +58,13 @@ final class UrlRule implements UrlRuleInterface
 
         // Redirect to correct slug language
         $url = ['/ruleclass/test', 'slugLanguage' => $language];
+
         Yii::$app->response->redirect($url);
 
         if (YII_ENV === 'test') {
             /**
              * Response::redirect($url) above will call `Url::to()` internally.
-             * So to really test for the same final redirect URL here, we need to call Url::to(), too.
+             * So to test for the same final redirect URL here, we need to call Url::to(), too.
              */
             throw new Exception(Url::to($url));
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved and clarified doc comments and PHPDoc annotations across the codebase, including detailed descriptions for classes, properties, and methods.
  - Updated the changelog with a new entry describing test code cleanup.

- **Refactor**
  - Standardized PHPUnit assertions to use static calls in test classes.
  - Enhanced type annotations and parameter flexibility in test classes for improved static analysis and maintainability.
  - Reformatted configuration files and comments for consistency and readability.

- **Bug Fixes**
  - Broadened exception handling in language URL parsing to improve robustness.

- **Chores**
  - Excluded specific test directories from static analysis and code style checks.
  - Cleaned up test code for better readability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->