### PR TITLE
chore: Update `Yii2` version in `composer.json` and installation guide to `2.0.53`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## 0.1.1 Under development
+## 0.1.1 June 27, 2025
 
 - Bug #19: Improve language in comments for clarity and consistency in `LanguageChangedEvent.php` and `UrlLanguageManager.php` (@terabytesoftw)
 - Bug #20: Clean up code in tests for better readability and maintainability (@terabytesoftw)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
         <img src="https://img.shields.io/badge/PHP-%3E%3D8.1-787CB5" alt="PHP Version">
     </a>
     <a href="https://github.com/yiisoft/yii2/tree/2.0.53" target="_blank">
-        <img src="https://img.shields.io/badge/Yii2%20-2.0.53-blue" alt="Yii2 22.0.53">
+        <img src="https://img.shields.io/badge/Yii2%20-2.0.53-blue" alt="Yii2 2.0.53">
     </a>
     <a href="https://github.com/yiisoft/yii2/tree/22.0" target="_blank">
         <img src="https://img.shields.io/badge/Yii2%20-22-blue" alt="Yii2 22.0">

--- a/README.md
+++ b/README.md
@@ -7,23 +7,26 @@
 </p>
 
 <p align="center">
-    <a href="https://www.php.net/releases/8.1/en.php" target="_blank">
-        <img src="https://img.shields.io/badge/PHP-%3E%3D8.1-787CB5" alt="PHP-Version">
+    <a href="https://github.com/yii2-extensions/phpstan" target="_blank">
+        <img src="https://img.shields.io/github/v/release/yii2-extensions/localeurls?color=blue" alt="GitHub Release">
     </a>
-    <a href="https://github.com/yiisoft/yii2/tree/2.0.52" target="_blank">
-        <img src="https://img.shields.io/badge/Yii2%20-2.0.52-blue" alt="Yii-22.0.52">
+    <a href="https://www.php.net/releases/8.1/en.php" target="_blank">
+        <img src="https://img.shields.io/badge/PHP-%3E%3D8.1-787CB5" alt="PHP Version">
+    </a>
+    <a href="https://github.com/yiisoft/yii2/tree/2.0.53" target="_blank">
+        <img src="https://img.shields.io/badge/Yii2%20-2.0.53-blue" alt="Yii2 22.0.53">
     </a>
     <a href="https://github.com/yiisoft/yii2/tree/22.0" target="_blank">
-        <img src="https://img.shields.io/badge/Yii2%20-22-blue" alt="Yii2-22">
+        <img src="https://img.shields.io/badge/Yii2%20-22-blue" alt="Yii2 22.0">
     </a>
     <a href="https://github.com/yii2-extensions/localeurls/actions/workflows/build.yml" target="_blank">
         <img src="https://github.com/yii2-extensions/localeurls/actions/workflows/build.yml/badge.svg" alt="PHPUnit">
     </a>
     <a href="https://dashboard.stryker-mutator.io/reports/github.com/yii2-extensions/localeurls/main" target="_blank">
-        <img src="https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2Fyii2-extensions%2Flocaleurls%2Fmain" alt="Mutation-Testing">
+        <img src="https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2Fyii2-extensions%2Flocaleurls%2Fmain" alt="Mutation Testing">
     </a>    
     <a href="https://github.com/yii2-extensions/localeurls/actions/workflows/static.yml" target="_blank">        
-        <img src="https://github.com/yii2-extensions/localeurls/actions/workflows/static.yml/badge.svg" alt="Static-Analysis">
+        <img src="https://github.com/yii2-extensions/localeurls/actions/workflows/static.yml/badge.svg" alt="Static Analysis">
     </a>
     <a href="https://codecov.io/gh/yii2-extensions/localeurls" target="_blank">
         <img src="https://codecov.io/gh/yii2-extensions/localeurls/graph/badge.svg?token=hLDHtLBgqV" alt="Codecov">

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 </p>
 
 <p align="center">
-    <a href="https://github.com/yii2-extensions/phpstan" target="_blank">
+    <a href="https://github.com/yii2-extensions/localeurls/releases" target="_blank">
         <img src="https://img.shields.io/github/v/release/yii2-extensions/localeurls?color=blue" alt="GitHub Release">
     </a>
     <a href="https://www.php.net/releases/8.1/en.php" target="_blank">

--- a/composer.json
+++ b/composer.json
@@ -8,12 +8,10 @@
         "locale"
     ],
     "license": "BSD-3-Clause",
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "require": {
         "php": ">=8.1",
         "ext-mbstring": "*",
-        "yiisoft/yii2": "^2.0.52 || ^22"
+        "yiisoft/yii2": "^2.0.53|^22"
     },
     "require-dev": {
         "infection/infection": "^0.27|^0.29",
@@ -24,7 +22,7 @@
         "phpunit/phpunit": "^10.5",
         "rector/rector": "^2.0",
         "symplify/easy-coding-standard": "^12.3",
-        "yii2-extensions/phpstan": "dev-main"
+        "yii2-extensions/phpstan": "^0.3.0"
     },
     "autoload": {
         "psr-4": {

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -3,7 +3,7 @@
 ## System requirements
 
 - [`PHP`](https://www.php.net/downloads) 8.1 or higher.
-- [`Yii2`](https://github.com/yiisoft/yii2) 2.0.52+ or 22.x.
+- [`Yii2`](https://github.com/yiisoft/yii2) 2.0.53+ or 22.x.
 
 ## Installation
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the changelog with a release date for version 0.1.1.
  * Improved README badges for clarity and accuracy, including a new GitHub release badge and updated Yii2 version information.
  * Updated installation documentation to require Yii2 version 2.0.53 or higher.

* **Chores**
  * Adjusted dependency version constraints and stability settings in the configuration to require newer versions and stable releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->