### PR TITLE
fix: Remove unused command coverage options from mutation workflow configuration.

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -21,7 +21,6 @@ jobs:
   mutation:
     uses: php-forge/actions/.github/workflows/infection.yml@v1
     with:
-      command-coverage-options: ''
       phpstan: true
     secrets:
       STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -21,7 +21,7 @@ jobs:
   mutation:
     uses: php-forge/actions/.github/workflows/infection.yml@v1
     with:
-      command-coverage-options: --with-uncovered
+      command-coverage-options: ''
       phpstan: true
     secrets:
       STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Bug #29: Add missing `Composer` requirement in the installation guide (@terabytesoftw)
 - Bug #30: Update license badge URL in `README.md` and add missing header in `LICENSE.md` (@terabytesoftw)
 - Bug #32: Update `.gitattributes` to exclude additional files from the package, update `LICENSE.md`, and add stable version workflow actions (@terabytesoftw)
+- Bug #33: Remove unused command coverage options from mutation workflow configuration (@terabytesoftw)
 
 ## 0.1.2 July 4, 2025
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Tests
  * Adjusted mutation testing configuration in CI, simplifying coverage options. This may slightly affect mutation test scope and reporting but does not impact application behavior.

* Chores
  * Retained existing CI settings for static analysis and secrets.
  * No changes to APIs or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->